### PR TITLE
Fixing problem with LCM build flag -extra_checks

### DIFF
--- a/tools/lcm.BUILD
+++ b/tools/lcm.BUILD
@@ -166,7 +166,7 @@ java_library(
     srcs = glob(["lcm-java/lcm/**/*.java"]),
     javacopts = [
         # Suppressed until lcm-proj/lcm#159 is fixed.
-        "-extra_checks:off",
+        "-XepDisableAllChecks",
     ],
     deps = [
         "@net_sf_jchart2d_jchart2d//jar",


### PR DESCRIPTION
I had a problem building optitrack-driver with the error:
```
ERROR: /private/var/tmp/_bazel_pvarin/1abef401a6fb0a02c719798fe12de17c/external/lcm/BUILD.bazel:164:1: Building external/lcm/liblcm-java.jar (32 source files) failed (Exit 1).
BazelJavaBuilder threw exception: -extra_checks is no longer supported; use -XepDisableAllChecks to disable Error Prone
```
Changing the `tools/lcm.BUILD` file fixed this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/optitrack-driver/3)
<!-- Reviewable:end -->
