### PR TITLE
Fix incompatible_restrict_string_escapes for bazel 4.0

### DIFF
--- a/tools/pathutils.bzl
+++ b/tools/pathutils.bzl
@@ -25,7 +25,7 @@ def join_paths(*args):
     This is roughly equivalent to Python's `os.path.join`.
 
     Args:
-        \*args (:obj:`list` of :obj:`str`): Path components to be joined.
+        *args (:obj:`list` of :obj:`str`): Path components to be joined.
 
     Returns:
         :obj:`str`: The concatenation of the input path components.


### PR DESCRIPTION
Relates https://github.com/RobotLocomotion/drake/issues/14440.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/optitrack-driver/11)
<!-- Reviewable:end -->
